### PR TITLE
Fix login/logout XML strings

### DIFF
--- a/lib/infrastructure/auth/router_auth_facade.dart
+++ b/lib/infrastructure/auth/router_auth_facade.dart
@@ -85,7 +85,7 @@ class RouterAuthFacade implements IAuthFacade {
         );
 
         final logininfo =
-            '<?xml version="1.0"encoding="UTF-8"?><request><Username>$usernameStr</Username><Password>$authinfo</Password><password_type>4</password_type>';
+            '<?xml version="1.0" encoding="UTF-8"?><request><Username>$usernameStr</Username><Password>$authinfo</Password><password_type>4</password_type></request>';
 
         final responseLogin = await _api.signInWithEmailAndPassword(logininfo);
 
@@ -144,7 +144,7 @@ class RouterAuthFacade implements IAuthFacade {
   @override
   Future<Either<AuthFailure, Unit>> signOut() async {
     const logoutInfo =
-        '<?xml version:"1.0" encoding="UTF-8"?><request><Logout>1</Logout></request>';
+        '<?xml version="1.0" encoding="UTF-8"?><request><Logout>1</Logout></request>';
 
     try {
       final response = await _api.logout(logoutInfo);

--- a/lib/infrastructure/auth/router_huawei_auth_facade.dart
+++ b/lib/infrastructure/auth/router_huawei_auth_facade.dart
@@ -81,7 +81,7 @@ class RouterHuaweiAuthFacade implements IAuthFacade {
         );
 
         final logininfo =
-            '<?xml version="1.0"encoding="UTF-8"?><request><Username>$usernameStr</Username><Password>$authinfo</Password><password_type>4</password_type>';
+            '<?xml version="1.0" encoding="UTF-8"?><request><Username>$usernameStr</Username><Password>$authinfo</Password><password_type>4</password_type></request>';
 
         final responseLogin =
             await _api.signInWithEmailAndPassword(logininfo).catchError(
@@ -199,7 +199,7 @@ class RouterHuaweiAuthFacade implements IAuthFacade {
   @override
   Future<Either<AuthFailure, Unit>> signOut() async {
     const logoutInfo =
-        '<?xml version:"1.0" encoding="UTF-8"?><request><Logout>1</Logout></request>';
+        '<?xml version="1.0" encoding="UTF-8"?><request><Logout>1</Logout></request>';
 
     try {
       final response = await _api.logout(logoutInfo).catchError(


### PR DESCRIPTION
## Summary
- ensure auth facades use valid XML for login requests
- use correct XML header for logout requests

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_684951b09f2883208ae7f23343a531b0